### PR TITLE
List supported GHC versions for make-travis-yml.

### DIFF
--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -300,8 +300,7 @@ parseOpts argv = case argv of
     _ -> parseOptsNoCommands argv
   where
     groupedVersions :: [(Version, [Version])]
-    groupedVersions = map (\vs -> (head vs, vs))
-                    . map (reverse . sort)
+    groupedVersions = map ((\vs -> (head vs, vs)) . reverse . sort)
                     . groupBy ((==) `on` ghcMajVer)
                     $ sort knownGhcVersions
 

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -300,7 +300,7 @@ parseOpts argv = case argv of
     _ -> parseOptsNoCommands argv
   where
     groupedVersions :: [(Version, [Version])]
-    groupedVersions = map (\vs@(v:_) -> (v, vs))
+    groupedVersions = map (\vs -> (head v, vs))
                     . map (reverse . sort)
                     . groupBy ((==) `on` ghcMajVer)
                     $ sort knownGhcVersions

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -300,7 +300,7 @@ parseOpts argv = case argv of
     _ -> parseOptsNoCommands argv
   where
     groupedVersions :: [(Version, [Version])]
-    groupedVersions = map (\vs -> (head v, vs))
+    groupedVersions = map (\vs -> (head vs, vs))
                     . map (reverse . sort)
                     . groupBy ((==) `on` ghcMajVer)
                     $ sort knownGhcVersions

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -300,7 +300,7 @@ parseOpts argv = case argv of
     _ -> parseOptsNoCommands argv
   where
     groupedVersions :: [(Version, [Version])]
-    groupedVersions = map ((\vs -> (head vs, vs)) . reverse . sort)
+    groupedVersions = map ((\vs -> (head vs, vs)) . sortBy (flip compare))
                     . groupBy ((==) `on` ghcMajVer)
                     $ sort knownGhcVersions
 


### PR DESCRIPTION
Simple new command to list the GHC versions supported by make-travis-yml, for forgetful people like me.