### PR TITLE
Fix --no-cabal-noise resulting in Travis incorrectly reporting test success.

### DIFF
--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -873,14 +873,14 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
     when hasTests $
         foldedTellStrLns FoldTest "Testing..." folds $ tellStrLns
             [ sh $ mconcat
-                [ "if [ \"x$TEST\" = \"x--enable-tests\" ]; then cabal "
+                [ "if [ \"x$TEST\" = \"x--enable-tests\" ]; then "
                 , if cfgNoise config
-                     then ""
-                     else "-vnormal+nowrap+markoutput "
+                     then "cabal "
+                     else "(set -o pipefail; cabal -vnormal+nowrap+markoutput "
                 , "new-test -w ${HC} ${TEST} ${BENCH} all"
                 , if cfgNoise config
                      then ""
-                     else " | sed '/^-----BEGIN CABAL OUTPUT-----$/,/^-----END CABAL OUTPUT-----$/d'"
+                     else " 2>&1 | sed '/^-----BEGIN CABAL OUTPUT-----$/,/^-----END CABAL OUTPUT-----$/d' )"
                 , "; fi"
                 ]
             ]


### PR DESCRIPTION
Seems like I accidentally broke Travis ability to detect failing tests when using --no-cabal-noise, this patch fixes that by propagating non-zero exit codes from shell pipelines.