### PR TITLE
There's only one .ghc.environment.* file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ install:
   - rm -f cabal.project.freeze
   - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project" --dep -j2 all
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project" --dep -j2 all
-  - rm -rf "."/.ghc.environment.* "."/dist
+  - rm -rf .ghc.environment.* "."/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
 # Here starts the actual work to be performed for the package under test;

--- a/fixtures/cabal.project.empty-line.travis.yml
+++ b/fixtures/cabal.project.empty-line.travis.yml
@@ -128,7 +128,7 @@ install:
   - rm -f cabal.project.freeze
   - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project.empty-line" --dep -j2 all
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project.empty-line" --dep -j2 all
-  - rm -rf "servant"/.ghc.environment.* "servant-client"/.ghc.environment.* "servant-docs"/.ghc.environment.* "servant-server"/.ghc.environment.* "servant"/dist "servant-client"/dist "servant-docs"/dist "servant-server"/dist
+  - rm -rf .ghc.environment.* "servant"/dist "servant-client"/dist "servant-docs"/dist "servant-server"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
 # Here starts the actual work to be performed for the package under test;

--- a/fixtures/cabal.project.messy.travis.yml
+++ b/fixtures/cabal.project.messy.travis.yml
@@ -126,7 +126,7 @@ install:
   - rm -f cabal.project.freeze
   - cabal new-build -w ${HC} ${TEST} ${BENCH} --project-file="cabal.project.messy" --dep -j2 all
   - cabal new-build -w ${HC} --disable-tests --disable-benchmarks --project-file="cabal.project.messy" --dep -j2 all
-  - rm -rf "servant"/.ghc.environment.* "servant-client"/.ghc.environment.* "servant-docs"/.ghc.environment.* "servant-server"/.ghc.environment.* "servant"/dist "servant-client"/dist "servant-docs"/dist "servant-server"/dist
+  - rm -rf .ghc.environment.* "servant"/dist "servant-client"/dist "servant-docs"/dist "servant-server"/dist
   - DISTDIR=$(mktemp -d /tmp/dist-test.XXXX)
 
 # Here starts the actual work to be performed for the package under test;

--- a/make_travis_yml_2.hs
+++ b/make_travis_yml_2.hs
@@ -812,7 +812,7 @@ genTravisFromConfigs (argv,opts) xpkgs isCabalProject config prj@Project { prjPa
         ]
 
     let quotedRmPaths =
-          quotedPaths (\Pkg{pkgDir} -> pkgDir ++ "/.ghc.environment.*")
+          ".ghc.environment.*"
           ++ " " ++
           quotedPaths (\Pkg{pkgDir} -> pkgDir ++ "/dist")
 


### PR DESCRIPTION
Should fix https://github.com/haskell-servant/servant-auth/pull/86